### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@ Supported chips:
 
 * AMD Family 17h Processors: Model 30h
 
-* AMD Family 19h Processors: Model 01h and 30h
-
-* AMD Family 19h Processors: Model 01h and 10h
-
-* AMD Family 19h Processors: Model 00h, 11h, A0h, 90h
+* AMD Family 19h Processors: Model 00h, 01h, 10h, 11h, 30h, 90h, and A0h
 
 * AMD Family 1Ah Processors: Model 00h, 02h, 11h, 10h
 


### PR DESCRIPTION
Unclear why there were three lines for the same family (17h also has Zen, Zen+, and Zen2) and 01h was duplicated. Ordered by value (A0h being last)