### PR TITLE
amd_energy: Fix version check for 6.8.0 -> 6.9.0

### DIFF
--- a/amd_energy.c
+++ b/amd_energy.c
@@ -236,7 +236,7 @@ static int amd_create_sensor(struct device *dev,
 	 * c->x86_max_cores is the linux count of physical cores
 	 * total physical cores/ core per socket gives total number of sockets.
 	 */
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(6, 8, 0)
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(6, 9, 0)
 	struct cpuinfo_x86 *c = &boot_cpu_data;
 	sockets = cpus / c->x86_max_cores;
 #else


### PR DESCRIPTION
The patches this check was added for ended up landing in v6.9 instead of v6.8, so this fixes the DKMS build on e.g. Ubuntu 24.04 LTS.

Closes #11

Fixes: c9e85067ba95 ("amd_energy: Conditionally check for x86_max_cores")